### PR TITLE
Engine: Do not emit optimistic change notifications unless the local value is different

### DIFF
--- a/common/dconf-changeset.c
+++ b/common/dconf-changeset.c
@@ -310,6 +310,20 @@ dconf_changeset_get (DConfChangeset  *changeset,
 }
 
 /**
+ * dconf_changeset_table_iter_init:
+ * @changeset: a #DConfChangeset
+ * @iter: a pointer to a #GHashTableIter
+ *
+ * Creates a hash table iterator for the table of @changeset
+ **/
+void
+dconf_changeset_table_iter_init (DConfChangeset *changeset,
+                                 GHashTableIter *iter)
+{
+  g_hash_table_iter_init (iter, changeset->table);
+}
+
+/**
  * dconf_changeset_is_similar_to:
  * @changeset: a #DConfChangeset
  * @other: another #DConfChangeset

--- a/common/dconf-changeset.h
+++ b/common/dconf-changeset.h
@@ -47,6 +47,9 @@ gboolean                dconf_changeset_get                             (DConfCh
                                                                          const gchar              *key,
                                                                          GVariant                **value);
 
+void                    dconf_changeset_table_iter_init                 (DConfChangeset           *changeset,
+                                                                         GHashTableIter           *iter);
+
 gboolean                dconf_changeset_is_similar_to                   (DConfChangeset           *changeset,
                                                                          DConfChangeset           *other);
 

--- a/engine/dconf-engine.c
+++ b/engine/dconf-engine.c
@@ -987,7 +987,7 @@ dconf_engine_changeset_has_no_effect (DConfEngine *engine, DConfChangeset *chang
   gpointer key, new_value;
   GVariant *current_value;
 
-  dconf_changeset_table_iter_init(changeset, &iter);
+  dconf_changeset_table_iter_init (changeset, &iter);
   while (g_hash_table_iter_next (&iter, &key, &new_value))
     {
       GVariant *current_value = dconf_engine_read (engine,
@@ -1003,16 +1003,16 @@ dconf_engine_changeset_has_no_effect (DConfEngine *engine, DConfChangeset *chang
         {
           if (new_value == NULL)
             {
-              g_variant_unref(current_value);
+              g_variant_unref (current_value);
               return FALSE;
             }
-          else if (!g_variant_equal(current_value, new_value))
+          else if (!g_variant_equal (current_value, new_value))
             {
-              g_variant_unref(current_value);
+              g_variant_unref (current_value);
               return FALSE;
             }
 
-          g_variant_unref(current_value);
+          g_variant_unref (current_value);
         }
     }
 

--- a/engine/dconf-engine.c
+++ b/engine/dconf-engine.c
@@ -995,13 +995,25 @@ dconf_engine_changeset_has_no_effect (DConfEngine *engine, DConfChangeset *chang
                                                    NULL,
                                                    key);
 
-      if (!g_variant_equal(current_value, new_value))
+      if (current_value == NULL)
         {
-          g_variant_unref(current_value);
           return FALSE;
         }
+      else
+        {
+          if (new_value == NULL)
+            {
+              g_variant_unref(current_value);
+              return FALSE;
+            }
+          else if (!g_variant_equal(current_value, new_value))
+            {
+              g_variant_unref(current_value);
+              return FALSE;
+            }
 
-      g_variant_unref(current_value);
+          g_variant_unref(current_value);
+        }
     }
 
   return TRUE;
@@ -1180,7 +1192,7 @@ dconf_engine_change_fast (DConfEngine     *engine,
   if (dconf_changeset_is_empty (changeset))
     return TRUE;
 
-  gboolean has_no_effect = !dconf_engine_changeset_has_no_effect (engine, changeset);
+  gboolean has_no_effect = dconf_engine_changeset_has_no_effect (engine, changeset);
 
   if (!dconf_engine_changeset_changes_only_writable_keys (engine, changeset, error))
     return FALSE;

--- a/engine/dconf-engine.c
+++ b/engine/dconf-engine.c
@@ -965,6 +965,48 @@ dconf_engine_prepare_change (DConfEngine     *engine,
  */
 static void dconf_engine_manage_queue (DConfEngine *engine);
 
+/**
+ * dconf_engine_changeset_has_no_effect:
+ * @engine: a #DConfEngine to check the effect of the changes on
+ * @changeset: a #DConfChangeset
+ * @read_through: a #GQueue to include pending changes from
+ *
+ * Checks if @changeset would have no effect when applied to @engine
+ * (i.e. for all changes, the new value is the same as the old value,
+ * or the same as the pending value in @read_through).
+ *
+ * Returns: %TRUE if @changeset is empty
+ **/
+gboolean
+dconf_engine_changeset_has_no_effect (DConfEngine *engine, DConfChangeset *changeset)
+{
+  if (dconf_changeset_is_empty (changeset))
+    return TRUE;
+
+  GHashTableIter iter;
+  gpointer key, new_value;
+  GVariant *current_value;
+
+  dconf_changeset_table_iter_init(changeset, &iter);
+  while (g_hash_table_iter_next (&iter, &key, &new_value))
+    {
+      GVariant *current_value = dconf_engine_read (engine,
+                                                   DCONF_READ_USER_VALUE,
+                                                   NULL,
+                                                   key);
+
+      if (!g_variant_equal(current_value, new_value))
+        {
+          g_variant_unref(current_value);
+          return FALSE;
+        }
+
+      g_variant_unref(current_value);
+    }
+
+  return TRUE;
+}
+
 static void
 dconf_engine_emit_changes (DConfEngine    *engine,
                            DConfChangeset *changeset,
@@ -1138,6 +1180,8 @@ dconf_engine_change_fast (DConfEngine     *engine,
   if (dconf_changeset_is_empty (changeset))
     return TRUE;
 
+  gboolean has_no_effect = !dconf_engine_changeset_has_no_effect (engine, changeset);
+
   if (!dconf_engine_changeset_changes_only_writable_keys (engine, changeset, error))
     return FALSE;
 
@@ -1189,7 +1233,8 @@ dconf_engine_change_fast (DConfEngine     *engine,
   dconf_engine_unlock_queues (engine);
 
   /* Emit the signal after dropping the lock to avoid deadlock on re-entry. */
-  dconf_engine_emit_changes (engine, changeset, origin_tag);
+  if (!has_no_effect)
+    dconf_engine_emit_changes (engine, changeset, origin_tag);
 
   return TRUE;
 }

--- a/engine/dconf-engine.h
+++ b/engine/dconf-engine.h
@@ -138,6 +138,10 @@ void                    dconf_engine_unwatch_fast                       (DConfEn
                                                                          const gchar             *path);
 
 G_GNUC_INTERNAL
+gboolean                dconf_engine_changeset_has_no_effect            (DConfEngine              *engine,
+                                                                         DConfChangeset           *changeset);
+
+G_GNUC_INTERNAL
 gboolean                dconf_engine_change_fast                        (DConfEngine             *engine,
                                                                          DConfChangeset          *changeset,
                                                                          gpointer                 origin_tag,

--- a/tests/engine.c
+++ b/tests/engine.c
@@ -1529,6 +1529,25 @@ test_change_sync (void)
 }
 
 static void
+test_change_effect (void)
+{
+  DConfChangeset *change, *empty_change;
+  DConfEngine *engine;
+
+  engine = dconf_engine_new (SRCDIR "/profile/dos", NULL, NULL);
+  change = dconf_changeset_new_write ("/value", g_variant_new_string ("value"));
+  empty_change = dconf_changeset_new();
+  g_assert_false(dconf_engine_changeset_has_no_effect(engine, change));
+  dconf_engine_change_fast(engine, change, NULL, NULL);
+  g_assert_true(dconf_engine_changeset_has_no_effect(engine, change));
+  g_assert_true(dconf_engine_changeset_has_no_effect(engine, empty_change));
+
+  dconf_changeset_unref(change);
+  dconf_changeset_unref(empty_change);
+  dconf_engine_unref(engine);
+}
+
+static void
 send_signal (GBusType     type,
              const gchar *name,
              const gchar *path,
@@ -1760,6 +1779,7 @@ main (int argc, char **argv)
   g_test_add_func ("/engine/watch/sync", test_watch_sync);
   g_test_add_func ("/engine/change/fast", test_change_fast);
   g_test_add_func ("/engine/change/sync", test_change_sync);
+  g_test_add_func ("/engine/change/effect", test_change_effect);
   g_test_add_func ("/engine/signals", test_signals);
   g_test_add_func ("/engine/sync", test_sync);
 

--- a/tests/engine.c
+++ b/tests/engine.c
@@ -1537,14 +1537,14 @@ test_change_effect (void)
   engine = dconf_engine_new (SRCDIR "/profile/dos", NULL, NULL);
   change = dconf_changeset_new_write ("/value", g_variant_new_string ("value"));
   empty_change = dconf_changeset_new();
-  g_assert_false(dconf_engine_changeset_has_no_effect(engine, change));
-  dconf_engine_change_fast(engine, change, NULL, NULL);
-  g_assert_true(dconf_engine_changeset_has_no_effect(engine, change));
-  g_assert_true(dconf_engine_changeset_has_no_effect(engine, empty_change));
+  g_assert_false (dconf_engine_changeset_has_no_effect (engine, change));
+  dconf_engine_change_fast (engine, change, NULL, NULL);
+  g_assert_true (dconf_engine_changeset_has_no_effect (engine, change));
+  g_assert_true (dconf_engine_changeset_has_no_effect (engine, empty_change));
 
-  dconf_changeset_unref(change);
-  dconf_changeset_unref(empty_change);
-  dconf_engine_unref(engine);
+  dconf_changeset_unref (change);
+  dconf_changeset_unref (empty_change);
+  dconf_engine_unref (engine);
 }
 
 static void


### PR DESCRIPTION
Currently when using the optimistic "fast" API, when a client requests a write to the database, changed signals are emitted to the clients of the engine process even if the writes did not result in the engine process's copy of the database changing values.

This results in infinite loops when client code such as gnome-shell and extensions perform writes as a result of changed notifications without checking if the new value is different from the old value. For example, it causes bugs like this: https://bugzilla.gnome.org/show_bug.cgi?id=782688

Client code can avoid this problem by keeping a reference to the current value of any watched setting and not performing writes as a result of changed signals when the new value is the same as the old value. This is impractical to fix (there are hundreds of places in gnome-shell and various extensions which do this). It is also a problem that if a single shell extension that does not perform this optimisation, the entire shell goes into  an infinite loop and hangs or crashes. The changed signal should not be sent in the first place unless they key has changed, and developers working with high level languages such as Javascript should not be responsible for handling the consequences of race conditions in multithreaded C code.

This change still sends the write request to the writer service in all cases, but does not emit local optimistic changed signals unless the changeset results in some value in the database being different to what it previously was. This breaks the infinite loops while still preserving the ability of the writer process/DBus to serialize all writes (and possibly still emit changed signals if the canonical copy of the database is changed by the write).

See existing discussion on bugzilla here: https://bugzilla.gnome.org/show_bug.cgi?id=789639