### PR TITLE
Service: only emit changed signals when values change

### DIFF
--- a/common/dconf-changeset.c
+++ b/common/dconf-changeset.c
@@ -868,7 +868,7 @@ dconf_changeset_diff (DConfChangeset *from,
    * Note: because 'from' and 'to' are database changesets we don't have
    * to worry about seeing NULL values or dirs.
    */
-  DConfChangeset *changeset = dconf_changeset_filter_changes(from, to);
+  DConfChangeset *changeset = dconf_changeset_filter_changes (from, to);
   GHashTableIter iter;
   gpointer key, val;
 

--- a/common/dconf-changeset.h
+++ b/common/dconf-changeset.h
@@ -65,6 +65,9 @@ DConfChangeset *        dconf_changeset_deserialise                     (GVarian
 void                    dconf_changeset_change                          (DConfChangeset           *changeset,
                                                                          DConfChangeset           *changes);
 
+DConfChangeset *        dconf_changeset_filter_changes                  (DConfChangeset           *from,
+                                                                         DConfChangeset           *changes);
+
 DConfChangeset *        dconf_changeset_diff                            (DConfChangeset           *from,
                                                                          DConfChangeset           *to);
 

--- a/service/dconf-writer.c
+++ b/service/dconf-writer.c
@@ -129,8 +129,8 @@ dconf_writer_real_change (DConfWriter    *writer,
                           const gchar    *tag)
 {
   g_return_if_fail (writer->priv->uncommited_values != NULL);
-  DConfChangeset *effective_changeset = dconf_changeset_filter_changes(writer->priv->commited_values,
-                                                                       changeset);
+  DConfChangeset *effective_changeset = dconf_changeset_filter_changes (writer->priv->commited_values,
+                                                                        changeset);
 
   if (effective_changeset)
     {

--- a/service/dconf-writer.c
+++ b/service/dconf-writer.c
@@ -129,21 +129,25 @@ dconf_writer_real_change (DConfWriter    *writer,
                           const gchar    *tag)
 {
   g_return_if_fail (writer->priv->uncommited_values != NULL);
+  DConfChangeset *effective_changeset = dconf_changeset_filter_changes(writer->priv->commited_values,
+                                                                       changeset);
 
-  dconf_changeset_change (writer->priv->uncommited_values, changeset);
-
-  if (tag)
+  if (effective_changeset)
     {
-      TaggedChange *change;
+      dconf_changeset_change (writer->priv->uncommited_values, effective_changeset);
+      if (tag)
+        {
+          TaggedChange *change;
 
-      change = g_slice_new (TaggedChange);
-      change->changeset = dconf_changeset_ref (changeset);
-      change->tag = g_strdup (tag);
+          change = g_slice_new (TaggedChange);
+          change->changeset = dconf_changeset_ref (effective_changeset);
+          change->tag = g_strdup (tag);
 
-      g_queue_push_tail (&writer->priv->uncommited_changes, change);
+          g_queue_push_tail (&writer->priv->uncommited_changes, change);
+        }
+
+      writer->priv->need_write = TRUE;
     }
-
-  writer->priv->need_write = TRUE;
 }
 
 static gboolean

--- a/tests/changeset.c
+++ b/tests/changeset.c
@@ -586,16 +586,16 @@ test_filter_changes (void)
   base = dconf_changeset_new_database (NULL);
   changes = dconf_changeset_new ();
   /* an empty changeset would not change an empty database */
-  g_assert_null (dconf_changeset_filter_changes(base, changes));
+  g_assert_null (dconf_changeset_filter_changes (base, changes));
   dconf_changeset_set (base, "/a", value1);
   /* an empty changeset would not change a database with values */
-  g_assert_null (dconf_changeset_filter_changes(base, changes));
+  g_assert_null (dconf_changeset_filter_changes (base, changes));
   dconf_changeset_set (changes, "/a", value1);
   /* a changeset would not change a database with the same values */
-  g_assert_null (dconf_changeset_filter_changes(base, changes));
+  g_assert_null (dconf_changeset_filter_changes (base, changes));
   dconf_changeset_set (changes, "/a", value2);
   /* a changeset would change a database with the same keys but different values */
-  g_assert_nonnull (dconf_changeset_filter_changes(base, changes));
+  g_assert_nonnull (dconf_changeset_filter_changes (base, changes));
 
   dconf_changeset_unref (base);
   dconf_changeset_unref (changes);

--- a/tests/changeset.c
+++ b/tests/changeset.c
@@ -572,6 +572,35 @@ test_diff (void)
     }
 }
 
+static void
+test_filter_changes (void)
+{
+  DConfChangeset *base, *changes;
+  gint i;
+  GVariant *value1 = g_variant_new_string ("value1");
+  GVariant *value2 = g_variant_new_string ("value2");
+
+  /* These tests are mostly negative, since dconf_changeset_filter_changes
+   * is called from dconf_changeset_diff */
+
+  base = dconf_changeset_new_database (NULL);
+  changes = dconf_changeset_new ();
+  /* an empty changeset would not change an empty database */
+  g_assert_null (dconf_changeset_filter_changes(base, changes));
+  dconf_changeset_set (base, "/a", value1);
+  /* an empty changeset would not change a database with values */
+  g_assert_null (dconf_changeset_filter_changes(base, changes));
+  dconf_changeset_set (changes, "/a", value1);
+  /* a changeset would not change a database with the same values */
+  g_assert_null (dconf_changeset_filter_changes(base, changes));
+  dconf_changeset_set (changes, "/a", value2);
+  /* a changeset would change a database with the same keys but different values */
+  g_assert_nonnull (dconf_changeset_filter_changes(base, changes));
+
+  dconf_changeset_unref (base);
+  dconf_changeset_unref (changes);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -584,6 +613,7 @@ main (int argc, char **argv)
   g_test_add_func ("/changeset/serialiser", test_serialiser);
   g_test_add_func ("/changeset/change", test_change);
   g_test_add_func ("/changeset/diff", test_diff);
+  g_test_add_func ("/changeset/filter", test_filter_changes);
 
   return g_test_run ();
 }


### PR DESCRIPTION
This change adds a check/filter to the writer service such that it only emits changed notifications for values in the database who's values changed as a result of the write.

Since the check is done in the central writer service which stores the canonical copy of the database, there is no opportunity for race conditions.

The issues caused by this bug are similar to https://github.com/GNOME/dconf/pull/1

See existing discussion on bugzilla here: https://bugzilla.gnome.org/show_bug.cgi?id=789639